### PR TITLE
Given any numbers, returns a list containing the power of those numbers

### DIFF
--- a/lib/projecttwo/power_list.ex
+++ b/lib/projecttwo/power_list.ex
@@ -1,0 +1,8 @@
+defmodule ProjecttwoWeb.PowerList do 
+    def list(numbers) do
+      listpower = Regex.split(~R//, numbers) -- ["",""]
+        |> Enum.map(&String.to_integer/1)
+          
+        for x <- listpower, do: x*x
+    end
+end

--- a/lib/projecttwo_web/controllers/Powerlist_controller.ex
+++ b/lib/projecttwo_web/controllers/Powerlist_controller.ex
@@ -1,0 +1,8 @@
+defmodule ProjecttwoWeb.PotenciaController do
+    use ProjecttwoWeb, :controller
+    alias ProjecttwoWeb.PowerList
+
+    def list(conn, %{"numbers" => numbers}) do 
+        json conn, %{powerlist: PowerList.list(numbers)}
+    end
+end 

--- a/lib/projecttwo_web/router.ex
+++ b/lib/projecttwo_web/router.ex
@@ -8,22 +8,8 @@ defmodule ProjecttwoWeb.Router do
   scope "/api", ProjecttwoWeb do
     pipe_through :api
 
-    resources "/users", UserController, except: [:new, :edit]    
-  end
-
-  # Enables LiveDashboard only for development
-  #
-  # If you want to use the LiveDashboard in production, you should put
-  # it behind authentication and allow only admins to access it.
-  # If your application does not have an admins-only section yet,
-  # you can use Plug.BasicAuth to set up some basic authentication
-  # as long as you are also using SSL (which you should anyway).
-  if Mix.env() in [:dev, :test] do
-    import Phoenix.LiveDashboard.Router
-
-    scope "/" do
-      pipe_through [:fetch_session, :protect_from_forgery]
-      live_dashboard "/dashboard", metrics: ProjecttwoWeb.Telemetry
-    end
+    resources "/users", UserController, except: [:new, :edit]  
+    
+    get "powerlist/:numbers", PotenciaController, :list
   end
 end


### PR DESCRIPTION
### ROUTERS

-  A new route with the verb get with a created parameter, but the parameter will arrive in the controller with string type.

### CONTROLLER

- In `power_list_controller.ex` I basically remove the parameter with a map, to be sent to our list function in `power_list.ex`

- Below we have the `Json` response, which goes inside {powerlist:[ ]} and inside the square brackets will be our function result in `power_list.ex`

### FUNCTION LIST

### In a basic way to understand

- Let's suppose that I passed the following numbers 1234, my numbers will arrive in the list function of type string, that is, "1234".

- My "1234" numbers will go into `Regex.split(~R//, "1234")` and will look like this, 
["", "1","2","3","4", ""],
   We noticed that it has two double quotes at the beginning and end, that's where the `-- ["",""]` comes in. It will eliminate those double quotes and leave the list like this
 ["1"," 2","3","4"].

- Now that we have our list of type string, below it goes into `Enum.map(&String.to_integer/1` and now it turns to type integer, our list is now [1,2,3,4].

- In `For` the list enters, `x` takes each number in the list and multiplies with itself, x=1, x*x = 1*1.

- And we have the power of each number on our list, [1,4,9,16].